### PR TITLE
[feat] Swagger option on Navbar

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -9,7 +9,7 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
-app.showSwaggerUILink=true
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-organic}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -8,3 +8,5 @@ spring.liquibase.url=${JDBC_DATABASE_URL}
 spring.liquibase.user=${JDBC_DATABASE_USERNAME}
 spring.liquibase.password=${JDBC_DATABASE_PASSWORD}
 spring.liquibase.enabled=true
+
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}


### PR DESCRIPTION
User Story:
As a developer I can easily turn on the swagger option on the app navbar for any deployment through defining an environment variable SHOW_SWAGGER_UI_LINK so that it is easy to access swagger when I need it, but I can easily turn it off when I don't.

Allows developer to set a variable called SHOW_SWAGGER_UI_LINK to true or false in their config variables.
When set to true:
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-3/assets/92059564/ef3bf18a-eed9-45eb-9bbc-9f97ecdcbc54)

When set to false:
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-3/assets/92059564/bf1a39b7-3cd7-47e6-88d5-3e5294e70c4b)

Closes #6