### PR TITLE
FEATURE: H2Console Option on Navbar for Development

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -8,7 +8,7 @@ spring.datasource.url=jdbc:h2:file:./target/db-development
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
-spring.h2.console.enabled=true
+spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:true}}
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-organic}}
 

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -10,3 +10,4 @@ spring.liquibase.password=${JDBC_DATABASE_PASSWORD}
 spring.liquibase.enabled=true
 
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
+spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:false}}


### PR DESCRIPTION
User Story:
As a developer I can easily turn on the h2console option on the app navbar for any deployment through defining an environment variable `H2_CONSOLE_ENABLED` so that it is easy to access the h2console when I need it, but I can easily turn it off when I don't.

Allows developer to set a variable called `H2_CONSOLE_ENABLED` to true or false in their config variables.
`H2_CONSOLE_ENABLED` is true:
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-3/assets/92059564/90868ee6-40c0-49a5-8f69-bb381d29bac5)

`H2_CONSOLE_ENABLED` is false:
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-3/assets/92059564/67cb2c18-4d0a-4f62-9f7b-3fbcf081723b)

Closes #19 