### PR TITLE
CRUD STAFF OPERATION Go to Staff Page from Course Page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,7 @@ import SchoolIndexPage from "main/pages/SchoolIndexPage";
 
 import CoursesCreatePage from "main/pages/CoursesCreatePage";
 import CourseIndexPage from "main/pages/CourseIndexPage";
+import CoursesStaffPage from "main/pages/CoursesStaffPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import NotFoundPage from "main/pages/NotFoundPage";
@@ -42,6 +43,12 @@ function App() {
       <Route path="/courses/create" element={<CoursesCreatePage />} />
       <Route path="/courses" element={<CourseIndexPage />} />
       <Route path="/courses/edit/:id" element={<CoursesEditPage />} />
+    </>
+  ) : null;
+
+  const staffRoutes = (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR") || hasRole(currentUser, "Role_USER")) ? (
+    <>
+      <Route path="/courses/:id/staff" element={<CoursesStaffPage />} />
     </>
   ) : null;
 
@@ -84,6 +91,7 @@ function App() {
           {adminRoutes}
           {userRoutes}
           {courseRoutes}
+          {staffRoutes}
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       )}

--- a/frontend/src/main/pages/CoursesStaffPage.js
+++ b/frontend/src/main/pages/CoursesStaffPage.js
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+//import { useParams } from "react-router-dom";
+//import StaffTable from 'main/components/Staff/StaffTable';
+//import { useBackend } from "main/utils/useBackend";
+
+
+export default function CoursesStaffPage() {
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Staff</h1>
+        
+          
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/CoursesStaffPage.js
+++ b/frontend/src/main/pages/CoursesStaffPage.js
@@ -1,7 +1,4 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-//import { useParams } from "react-router-dom";
-//import StaffTable from 'main/components/Staff/StaffTable';
-//import { useBackend } from "main/utils/useBackend";
 
 
 export default function CoursesStaffPage() {

--- a/frontend/src/tests/pages/CoursesStaffPage.test.js
+++ b/frontend/src/tests/pages/CoursesStaffPage.test.js
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import CoursesStaffPage from "main/pages/CoursesStaffPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("PlaceholderIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesStaffPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Staff")).toBeInTheDocument();
+    });
+
+});

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -8,7 +8,7 @@ spring.datasource.url=jdbc:h2:file:./target/db-development
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
-spring.h2.console.enabled=true
+spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:true}}
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-organic}}
 

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -8,7 +8,7 @@ spring.datasource.url=jdbc:h2:file:./target/db-development
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
-spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:true}}
+spring.h2.console.enabled=true
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-organic}}
 

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -10,3 +10,4 @@ spring.liquibase.password=${JDBC_DATABASE_PASSWORD}
 spring.liquibase.enabled=true
 
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
+spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:false}}

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -8,6 +8,4 @@ spring.liquibase.url=${JDBC_DATABASE_URL}
 spring.liquibase.user=${JDBC_DATABASE_USERNAME}
 spring.liquibase.password=${JDBC_DATABASE_PASSWORD}
 spring.liquibase.enabled=true
-
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
-spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:false}}

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -8,4 +8,5 @@ spring.liquibase.url=${JDBC_DATABASE_URL}
 spring.liquibase.user=${JDBC_DATABASE_USERNAME}
 spring.liquibase.password=${JDBC_DATABASE_PASSWORD}
 spring.liquibase.enabled=true
+
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}


### PR DESCRIPTION
User Story:
I can go to the staff page from the course page

dokku dev build: https://organic-andrewkwon-dev.dokku-11.cs.ucsb.edu

Clicking on staff button on the course page leads to a placeholder staff page. 
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-3/assets/92059564/250853b8-37d6-44fd-b66e-d0e91232ea3c)

![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-3/assets/92059564/12367743-cabb-4b03-a20e-04cc98465f56)

Other members can now work on other crud operations. There maybe some merge conflicts with App.js
Closes #37 