### PR TITLE
[reopen][feat] Expose git info msg #35

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV NODE_VERSION=16.20.0
 RUN apk add curl
 RUN apk add bash
 RUN apk add maven
+RUN apk add git
 RUN apk add --no-cache libstdc++
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
@@ -18,10 +19,7 @@ ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN node --version
 RUN npm --version
 
-COPY frontend /home/app/frontend
-COPY src /home/app/src
-COPY lombok.config /home/app
-COPY pom.xml /home/app
+COPY . /home/app
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,25 @@
                     <propertyFile>liquibase.properties</propertyFile>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>8.0.2</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                </configuration>
+            </plugin>
 
         </plugins>
 

--- a/src/main/java/edu/ucsb/cs156/organic/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/organic/models/SystemInfo.java
@@ -14,4 +14,7 @@ public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;
   private String sourceRepo;
+  private String commitMessage;
+  private String commitId;
+  private String githubUrl; // URL to the commit in the source repository
 }

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -1,6 +1,5 @@
 package edu.ucsb.cs156.organic.services;
 
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -15,24 +14,37 @@ import edu.ucsb.cs156.organic.models.SystemInfo;
 @Service("systemInfo")
 @ConfigurationProperties
 public class SystemInfoServiceImpl extends SystemInfoService {
-  
+
   @Value("${spring.h2.console.enabled:false}")
   private boolean springH2ConsoleEnabled;
 
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
-  @Value("${app.sourceRepo}")
-  private String sourceRepo = "https://github.com/ucsb-cs156/proj-organic";
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-courses}")
+  private String sourceRepo;
+
+  @Value("${git.commit.message.short:unknown}")
+  private String commitMessage;
+
+  @Value("${git.commit.id.abbrev:unknown}")
+  private String commitId;
+
+  public static String githubUrl(String repo, String commit) {
+    return commit != null && repo != null ? repo + "/commit/" + commit : null;
+  }
 
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()
-    .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
-    .showSwaggerUILink(this.showSwaggerUILink)
-    .sourceRepo(this.sourceRepo)
-    .build();
-  log.info("getSystemInfo returns {}",si);
-  return si;
+        .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
+        .showSwaggerUILink(this.showSwaggerUILink)
+        .sourceRepo(this.sourceRepo)
+        .commitMessage(this.commitMessage)
+        .commitId(this.commitId)
+        .githubUrl(githubUrl(this.sourceRepo, this.commitId))
+        .build();
+    log.info("getSystemInfo returns {}", si);
+    return si;
   }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.port=${PORT:8080}
-
+spring.config.import=git.properties
 # There are two settings for spring.jpa.hibernate.ddl-auto, namely "update" and "none"
 # Normally the value should be none, because we are using liquibase to manage migrations
 # However, temporarily, the value may need to be "update" when you want tables created

--- a/src/test/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImplTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.organic.services;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,20 @@ class SystemInfoServiceImplTests  {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
-    assertEquals("https://github.com/ucsb-cs156/proj-organic", si.getSourceRepo());
+    assertTrue(si.getGithubUrl().startsWith(si.getSourceRepo()));
+    assertTrue(si.getGithubUrl().endsWith(si.getCommitId()));
+    assertTrue(si.getGithubUrl().contains("/commit/"));
+  }
+
+  @Test
+  void test_githubUrl() {
+    assertEquals(
+        SystemInfoServiceImpl.githubUrl(
+            "https://github.com/ucsb-cs156/proj-courses", "abcdef12345"),
+        "https://github.com/ucsb-cs156/proj-courses/commit/abcdef12345");
+    assertNull(SystemInfoServiceImpl.githubUrl(null, null));
+    assertNull(SystemInfoServiceImpl.githubUrl("x", null));
+    assertNull(SystemInfoServiceImpl.githubUrl(null, "x"));
   }
 
 }


### PR DESCRIPTION
This is a reopen of PR #35, with changes seperated.

This PR addresses the need proposed by issue #2, where the information of the last commit is exposed in the sysinfo API endpoint.

Please see a live demo here: https://organic-yuxiaolejs-dev.dokku-11.cs.ucsb.edu/api/systemInfo

Closes #2 
