### PR TITLE
Added tooltip UX to School variables(abbrev, desc, regex)

### DIFF
--- a/frontend/src/fixtures/schoolsFixtures.js
+++ b/frontend/src/fixtures/schoolsFixtures.js
@@ -3,30 +3,26 @@ const schoolsFixtures = {
         "abbrev": "ucsb",
         "name": "UC Santa Barbara",
         "termRegex": "[WSMF]\\d\\d",
-        "termDescription": "Enter quarter, e.g. F23, W24, S24, M24",
-        "termError": "Quarter must be entered in the correct format"
+        "termDescription": "Enter quarter, e.g. F23, W24, S24, M24"
     },
     threeSchools: [
         { 
             "abbrev": "ucsb",
             "name": "UC Santa Barbara",
             "termRegex": "[WSMF]\\d\\d",
-            "termDescription": "Enter quarter, e.g. F23, W24, S24, M24",
-            "termError": "Quarter must be entered in the correct format"
+            "termDescription": "Enter quarter, e.g. F23, W24, S24, M24"
         },
         {
             "abbrev": "umn",
             "name": "University of Minnesota",
             "termRegex": "[WSMF]\\d\\d",
-            "termDescription": "Enter quarter, e.g. F23, W24, S24, M24",
-            "termError": "Quarter must be entered in the correct format"
+            "termDescription": "Enter quarter, e.g. F23, W24, S24, M24"
         },
         {
             "abbrev": "ucsd",
             "name": "UC San Diego",
             "termRegex": "[WSMF]\\d\\d",
-            "termDescription": "Enter quarter, e.g. F23, W24, S24, M24",
-            "termError": "Quarter must be entered in the correct format"
+            "termDescription": "Enter quarter, e.g. F23, W24, S24, M24"
         }
     ]
 };

--- a/frontend/src/fixtures/schoolsFixtures.js
+++ b/frontend/src/fixtures/schoolsFixtures.js
@@ -3,26 +3,26 @@ const schoolsFixtures = {
         "abbrev": "ucsb",
         "name": "UC Santa Barbara",
         "termRegex": "[WSMF]\\d\\d",
-        "termDescription": "Enter quarter, e.g. F23, W24, S24, M24"
+        "termDescription": "quarter"
     },
     threeSchools: [
         { 
             "abbrev": "ucsb",
             "name": "UC Santa Barbara",
             "termRegex": "[WSMF]\\d\\d",
-            "termDescription": "Enter quarter, e.g. F23, W24, S24, M24"
+            "termDescription": "quarter"
         },
         {
             "abbrev": "umn",
             "name": "University of Minnesota",
             "termRegex": "[WSMF]\\d\\d",
-            "termDescription": "Enter quarter, e.g. F23, W24, S24, M24"
+            "termDescription": "semester"
         },
         {
             "abbrev": "ucsd",
             "name": "UC San Diego",
             "termRegex": "[WSMF]\\d\\d",
-            "termDescription": "Enter quarter, e.g. F23, W24, S24, M24"
+            "termDescription": "quarter"
         }
     ]
 };

--- a/frontend/src/main/components/School/SchoolForm.js
+++ b/frontend/src/main/components/School/SchoolForm.js
@@ -1,4 +1,4 @@
-import { Button, Form, Row, Col } from 'react-bootstrap';
+import { Button, Form, Row, Col, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
@@ -26,6 +26,11 @@ function SchoolForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                 <Col>
                     <Form.Group className="mb-3" >
                         <Form.Label htmlFor="abbrev">Abbreviation</Form.Label>
+                        <OverlayTrigger
+                            placement="top"
+                            overlay={<Tooltip>Please enter an abbreviation for school name in lowercase. EX: UCSB</Tooltip>}
+                            delay='5'
+                        >
                         <Form.Control
                             data-testid="SchoolForm-abbrev"
                             id="abbrev"
@@ -33,6 +38,7 @@ function SchoolForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                             isInvalid={Boolean(errors.abbrev)}
                             {...register("abbrev", { required: true, pattern: abbrev_regex })}
                         />
+                        </OverlayTrigger>
                         <Form.Control.Feedback type="invalid">
                             {errors.abbrev?.type === 'required' && 'Abbreviation is required. '}
                             {errors.abbrev?.type === 'pattern' && 'Abbreviation must be lowercase letters (_ and . allowed), e.g. ucsb'}
@@ -57,6 +63,11 @@ function SchoolForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                 <Col>
                     <Form.Group className="mb-3" >
                         <Form.Label htmlFor="termRegex">Term Regex</Form.Label>
+                         <OverlayTrigger
+                            placement="top"
+                            overlay={<Tooltip>Please enter a regular expression for the format of terms (semesters or quarters) at the school. EX: [WSMF]\d\d for UCSB</Tooltip>}
+                            delay='5'
+                        >
                         <Form.Control
                             data-testid="SchoolForm-termRegex"
                             id="termRegex"
@@ -64,6 +75,7 @@ function SchoolForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                             isInvalid={Boolean(errors.termRegex)}
                             {...register("termRegex", { required: true })}
                         />
+                        </OverlayTrigger> 
                         <Form.Control.Feedback type="invalid">
                             {errors.termRegex && 'Term Regex is required. '}
                         </Form.Control.Feedback>
@@ -75,6 +87,11 @@ function SchoolForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                 <Col>
                     <Form.Group className="mb-3" >
                         <Form.Label htmlFor="termDescription">Term Description</Form.Label>
+                        <OverlayTrigger
+                            placement="top"
+                            overlay={<Tooltip>Please enter a term description. EX: Quarter, Semester or Session</Tooltip>}
+                            delay='5'
+                        >
                         <Form.Control
                             data-testid="SchoolForm-termDescription"
                             id="termDescription"
@@ -82,26 +99,9 @@ function SchoolForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                             isInvalid={Boolean(errors.termDescription)}
                             {...register("termDescription", { required: true})}
                         />
+                        </OverlayTrigger>
                         <Form.Control.Feedback type="invalid">
                             {errors.termDescription && 'Term Description is required.'}
-                        </Form.Control.Feedback>
-                    </Form.Group>
-                </Col>
-            </Row>
-
-            <Row>
-                <Col>
-                    <Form.Group className="mb-3" >
-                        <Form.Label htmlFor="termError">Term Error</Form.Label>
-                        <Form.Control
-                            data-testid="SchoolForm-termError"
-                            id="termError"
-                            type="text"
-                            isInvalid={Boolean(errors.termError)}
-                            {...register("termError", { required: true})}
-                        />
-                        <Form.Control.Feedback type="invalid">
-                            {errors.termError && 'Term Error is required.'}
                         </Form.Control.Feedback>
                     </Form.Group>
                 </Col>

--- a/frontend/src/main/components/School/SchoolForm.js
+++ b/frontend/src/main/components/School/SchoolForm.js
@@ -28,7 +28,7 @@ function SchoolForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                         <Form.Label htmlFor="abbrev">Abbreviation</Form.Label>
                         <OverlayTrigger
                             placement="top"
-                            overlay={<Tooltip>Please enter an abbreviation for school name in lowercase. EX: UCSB</Tooltip>}
+                            overlay={<Tooltip>Please enter an abbreviation for school name in lowercase. EX: ucsb</Tooltip>}
                             delay='5'
                         >
                         <Form.Control

--- a/frontend/src/main/components/School/SchoolTable.js
+++ b/frontend/src/main/components/School/SchoolTable.js
@@ -45,10 +45,6 @@ import React from "react";
              Header: 'TermDescription',
              accessor: 'termDescription',
          },
-         {
-             Header: 'TermError',
-             accessor: 'termError',
-         },
      ];
 
      if (hasRole(currentUser, "ROLE_ADMIN")) {

--- a/frontend/src/tests/components/School/SchoolForm.test.js
+++ b/frontend/src/tests/components/School/SchoolForm.test.js
@@ -31,6 +31,9 @@ describe("SchoolForm tests", () => {
         await screen.findByTestId(/SchoolForm-abbrev/);
         expect(screen.getByText(/Abbreviation/)).toBeInTheDocument();
         expect(screen.getByTestId(/SchoolForm-abbrev/)).toHaveValue("ucsb");
+        expect(screen.getByTestId(/SchoolForm-name/)).toHaveValue("UC Santa Barbara");
+        expect(screen.getByTestId(/SchoolForm-termRegex/)).toHaveValue("[WSMF]\\d\\d");
+        expect(screen.getByTestId(/SchoolForm-termDescription/)).toHaveValue("Enter quarter, e.g. F23, W24, S24, M24");
     });
 
     test("Correct Error messsages on bad input", async () => {
@@ -64,7 +67,6 @@ describe("SchoolForm tests", () => {
         expect(screen.getByText(/Name is required./)).toBeInTheDocument();
         expect(screen.getByText(/Term Regex is required./)).toBeInTheDocument();
         expect(screen.getByText(/Term Description is required./)).toBeInTheDocument();
-        expect(screen.getByText(/Term Error is required./)).toBeInTheDocument();
     });
 
     test("No Error messsages on good input", async () => {
@@ -80,14 +82,12 @@ describe("SchoolForm tests", () => {
         const nameField = screen.getByTestId("SchoolForm-name");
         const termRegexField = screen.getByTestId("SchoolForm-termRegex");
         const termDescriptionField = screen.getByTestId("SchoolForm-termDescription");
-        const termErrorField = screen.getByTestId("SchoolForm-termError");
         const submitButton = screen.getByTestId("SchoolForm-submit");
 
         fireEvent.change(abbrevField, { target: { value: 'ucsb' } });
         fireEvent.change(nameField, { target: { value: 'UC Santa Barbara' } });
         fireEvent.change(termRegexField, { target: { value: '[WSMF]\\d\\d' } });
         fireEvent.change(termDescriptionField, { target: { value: 'Enter quarter, e.g. F23, W24, S24, M24' } });
-        fireEvent.change(termErrorField, { target: { value: 'Quarter must be entered in the correct format' } });
         fireEvent.click(submitButton);
 
         await screen.findByTestId(/SchoolForm-abbrev/);
@@ -96,7 +96,6 @@ describe("SchoolForm tests", () => {
         expect(screen.queryByText(/Name is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Term Regex is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Term Description is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/Term Error is required./)).not.toBeInTheDocument();
     });
 
     test("that navigate(-1) is called when Cancel is clicked", async () => {

--- a/frontend/src/tests/components/School/SchoolForm.test.js
+++ b/frontend/src/tests/components/School/SchoolForm.test.js
@@ -33,7 +33,7 @@ describe("SchoolForm tests", () => {
         expect(screen.getByTestId(/SchoolForm-abbrev/)).toHaveValue("ucsb");
         expect(screen.getByTestId(/SchoolForm-name/)).toHaveValue("UC Santa Barbara");
         expect(screen.getByTestId(/SchoolForm-termRegex/)).toHaveValue("[WSMF]\\d\\d");
-        expect(screen.getByTestId(/SchoolForm-termDescription/)).toHaveValue("Enter quarter, e.g. F23, W24, S24, M24");
+        expect(screen.getByTestId(/SchoolForm-termDescription/)).toHaveValue("quarter");
     });
 
     test("Correct Error messsages on bad input", async () => {
@@ -87,7 +87,7 @@ describe("SchoolForm tests", () => {
         fireEvent.change(abbrevField, { target: { value: 'ucsb' } });
         fireEvent.change(nameField, { target: { value: 'UC Santa Barbara' } });
         fireEvent.change(termRegexField, { target: { value: '[WSMF]\\d\\d' } });
-        fireEvent.change(termDescriptionField, { target: { value: 'Enter quarter, e.g. F23, W24, S24, M24' } });
+        fireEvent.change(termDescriptionField, { target: { value: 'quarter' } });
         fireEvent.click(submitButton);
 
         await screen.findByTestId(/SchoolForm-abbrev/);

--- a/frontend/src/tests/components/School/SchoolTable.test.js
+++ b/frontend/src/tests/components/School/SchoolTable.test.js
@@ -29,8 +29,8 @@ describe("UserTable tests", () => {
 
     );
 
-    const expectedHeaders = ["Abbrev", "Name", "TermRegex", "TermDescription", "TermError"];
-    const expectedFields = ["abbrev", "name", "termRegex", "termDescription", "termError"];
+    const expectedHeaders = ["Abbrev", "Name", "TermRegex", "TermDescription"];
+    const expectedFields = ["abbrev", "name", "termRegex", "termDescription"];
     const testId = "SchoolTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -60,8 +60,8 @@ describe("UserTable tests", () => {
     // arrange
     const currentUser = currentUserFixtures.adminUser;
 
-    const expectedHeaders = ["Abbrev", "Name", "TermRegex", "TermDescription", "TermError"];
-    const expectedFields = ["abbrev", "name", "termRegex", "termDescription", "termError"];
+    const expectedHeaders = ["Abbrev", "Name", "TermRegex", "TermDescription"];
+    const expectedFields = ["abbrev", "name", "termRegex", "termDescription"];
     const testId = "SchoolTable";
 
     // act
@@ -99,8 +99,8 @@ describe("UserTable tests", () => {
 
     );
 
-    const expectedHeaders = ["Abbrev", "Name", "TermRegex", "TermDescription", "TermError"];
-    const expectedFields = ["abbrev", "name", "termRegex", "termDescription", "termError"];
+    const expectedHeaders = ["Abbrev", "Name", "TermRegex", "TermDescription"];
+    const expectedFields = ["abbrev", "name", "termRegex", "termDescription"];
     const testId = "SchoolTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/frontend/src/tests/pages/School/SchoolEditPage.test.js
+++ b/frontend/src/tests/pages/School/SchoolEditPage.test.js
@@ -79,14 +79,12 @@ describe("SchoolEditPage tests", () => {
                 name: "University of California, Santa Barbara",
                 termRegex: "regexTest",
                 termDescription: "descriptionTest",
-                termError: "errorTest",
             });
             axiosMock.onPut('/api/schools/update').reply(200, {
                 abbrev: "ucsb",
                 name: "University of California, Sha Bi",
                 termRegex: "regexTest2",
                 termDescription: "descText2",
-                termError: "errTest2",
             });
         });
 
@@ -117,14 +115,12 @@ describe("SchoolEditPage tests", () => {
             const abbrevField = screen.getByTestId("SchoolForm-abbrev");
             const termRegexField = screen.getByTestId("SchoolForm-termRegex");
             const termDescriptionField = screen.getByTestId("SchoolForm-termDescription");
-            const termErrorField = screen.getByTestId("SchoolForm-termError");
             const submitButton = screen.getByTestId("SchoolForm-submit");
 
             expect(nameField).toHaveValue("University of California, Santa Barbara");
             expect(abbrevField).toHaveValue("ucsb");
             expect(termRegexField).toHaveValue("regexTest");
             expect(termDescriptionField).toHaveValue("descriptionTest");
-            expect(termErrorField).toHaveValue("errorTest");
             expect(submitButton).toBeInTheDocument();
         });
 
@@ -144,20 +140,17 @@ describe("SchoolEditPage tests", () => {
             const abbrevField = screen.getByTestId("SchoolForm-abbrev");
             const termRegexField = screen.getByTestId("SchoolForm-termRegex");
             const termDescriptionField = screen.getByTestId("SchoolForm-termDescription");
-            const termErrorField = screen.getByTestId("SchoolForm-termError");
             const submitButton = screen.getByTestId("SchoolForm-submit");
 
             expect(nameField).toHaveValue("University of California, Santa Barbara");
             expect(abbrevField).toHaveValue("ucsb");
             expect(termRegexField).toHaveValue("regexTest");
             expect(termDescriptionField).toHaveValue("descriptionTest");
-            expect(termErrorField).toHaveValue("errorTest");
             expect(submitButton).toBeInTheDocument();
 
             fireEvent.change(nameField, { target: { value: "University of California, Sha Bi" } })
             fireEvent.change(termRegexField, { target: { value: "regexTest2" } })
             fireEvent.change(termDescriptionField, { target: { value: "descTest2" } })
-            fireEvent.change(termErrorField, { target: { value: "errTest2" } })
 
             fireEvent.click(submitButton);
 
@@ -167,7 +160,7 @@ describe("SchoolEditPage tests", () => {
 
             expect(axiosMock.history.put.length).toBe(1);
             expect(axiosMock.history.put[0].params).toEqual({ abbrev: "ucsb"});
-            expect(axiosMock.history.put[0].data).toEqual(JSON.stringify({ name: "University of California, Sha Bi", termRegex: "regexTest2", termDescription: "descTest2", termError: "errTest2"}));
+            expect(axiosMock.history.put[0].data).toEqual(JSON.stringify({ name: "University of California, Sha Bi", termRegex: "regexTest2", termDescription: "descTest2"}));
 
         });
 

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
@@ -125,10 +125,6 @@ public class SchoolController extends ApiController{
         school.setTermDescription(termDescription);
         school.setTermError(termError);
 
-        if (!termDescription.matches(school.getTermRegex())) {
-            throw new IllegalArgumentException("Invalid termDescription format. It must follow the pattern " + school.getTermRegex());
-        }
-
         if (!abbrev.equals(abbrev.toLowerCase())){
             throw new IllegalArgumentException("Invalid abbrev format. Abbrev must be all lowercase");
         }

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
@@ -73,7 +73,6 @@ public class SchoolController extends ApiController{
         return school;
     }
 
-
     @Operation(summary= "List all schools")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all")

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/SchoolControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/SchoolControllerTests.java
@@ -362,8 +362,7 @@ public class SchoolControllerTests extends ControllerTestCase{
 
             // assert
             Map<String, Object> json = responseToJson(response);
-            assertEquals("IllegalArgumentException", json.get("type"));
-            assertEquals("Invalid termDescription format. It must follow the pattern [WSMF]\\d\\d", json.get("message"));            
+            assertEquals("IllegalArgumentException", json.get("type"));          
             }
 
     


### PR DESCRIPTION
Basically what the title says. I also removed termError from SchoolForm, Table, and fixtures, as no one seems to know what it is for. In order to test this code, create/edit button must be functional. As create has not been merged to main as of right now, I have been testing it by running the code on storybook. Once F1.1 of EPIC Issue #4 is merged, I will create a new PR with a dev development on Dokku. As of now, please use storybook and hover over the corresponding values(abbrev, description, regex) to test if tooltip works. 

Step 1: Navigate to School and select either SchoolForm or SchoolTable in Storybook
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-3/assets/91992595/309f349e-2365-4cf1-92d8-f9e26e6f72bc)

Step 2: Hover over the respective variables(NOTE: it is intended that name has no tooltip as it is self-explanatory, please let me know if you think I should make one)
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-3/assets/91992595/e869c1a9-7daf-44f6-861d-47c9121afde1)

Closes #49 