### PR TITLE
[merge] Feature: add a single student to the course API

### DIFF
--- a/src/main/java/edu/ucsb/cs156/organic/controllers/StudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/StudentsController.java
@@ -63,9 +63,6 @@ public class StudentsController extends ApiController {
     @Autowired
     UserRepository userRepository;
 
-    @Autowired
-    StaffRepository courseStaffRepository;
-
     @Operation(summary = "Get Students for course")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/all")
@@ -81,27 +78,24 @@ public class StudentsController extends ApiController {
     }
 
     @Operation(summary = "Create a new student for a course")
-    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_INSTRUCTOR')")
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_INSTRUCTOR', 'ROLE_USER')")
+    // @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public Student postStudent(
             @Parameter(name = "courseId", description = "course ID") @RequestParam Long courseId,
             @Parameter(name = "email", description = "Email of the student") @RequestParam String email,
             @Parameter(name = "fname", description = "First name") @RequestParam String fname,
-            @Parameter(name = "githubId", description = "Github ID") @RequestParam Integer githubId,
             @Parameter(name = "lname", description = "Last name") @RequestParam String lname,
-            @Parameter(name = "studentId", description = "Student ID") @RequestParam String studentId)
-            throws JsonProcessingException {
-
+            @Parameter(name = "studentId", description = "Student ID") @RequestParam String studentId) {
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
         User u = getCurrentUser().getUser();
         if (!u.isAdmin()) {
-            courseStaffRepository.findByCourseIdAndGithubId(course.getId(), u.getGithubId())
+            staffRepository.findByCourseIdAndGithubId(course.getId(), u.getGithubId())
                     .orElseThrow(() -> new AccessDeniedException(
                             "User is not a staff member for this course"));
         }
         Student student = Student.builder().courseId(course.getId()).email(email).fname(fname)
-                .githubId(githubId)
                 .lname(lname).studentId(studentId).build();
         studentRepository.save(student);
         return student;

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/StudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/StudentsController.java
@@ -1,7 +1,9 @@
 package edu.ucsb.cs156.organic.controllers;
 
 import edu.ucsb.cs156.organic.entities.Course;
+import edu.ucsb.cs156.organic.entities.Staff;
 import edu.ucsb.cs156.organic.entities.Student;
+import edu.ucsb.cs156.organic.entities.User;
 import edu.ucsb.cs156.organic.repositories.CourseRepository;
 import edu.ucsb.cs156.organic.repositories.StaffRepository;
 import edu.ucsb.cs156.organic.repositories.StudentRepository;
@@ -16,6 +18,8 @@ import com.opencsv.CSVReader;
 import com.opencsv.exceptions.CsvException;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,6 +36,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -42,92 +47,122 @@ import java.util.Optional;
 @Slf4j
 public class StudentsController extends ApiController {
 
-        public enum Status {
-                INSERTED, UPDATED
-        };
+    public enum Status {
+        INSERTED, UPDATED
+    };
 
-        @Autowired
-        CourseRepository courseRepository;
+    @Autowired
+    CourseRepository courseRepository;
 
-        @Autowired
-        StaffRepository staffRepository;
+    @Autowired
+    StaffRepository staffRepository;
 
-        @Autowired
-        StudentRepository studentRepository;
+    @Autowired
+    StudentRepository studentRepository;
 
-        @Autowired
-        UserRepository userRepository;
+    @Autowired
+    UserRepository userRepository;
 
-        @Operation(summary = "Get Students for course")
-        @PreAuthorize("hasRole('ROLE_ADMIN')")
-        @GetMapping("/all")
-        public Iterable<Student> getStaff(
-                        @Parameter(name = "courseId") @RequestParam Long courseId)
-                        throws JsonProcessingException {
+    @Autowired
+    StaffRepository courseStaffRepository;
 
-                Course course = courseRepository.findById(courseId)
-                                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
+    @Operation(summary = "Get Students for course")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/all")
+    public Iterable<Student> getStaff(
+            @Parameter(name = "courseId") @RequestParam Long courseId)
+            throws JsonProcessingException {
 
-                Iterable<Student> students = studentRepository.findByCourseId(course.getId());
-                return students;
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
+
+        Iterable<Student> students = studentRepository.findByCourseId(course.getId());
+        return students;
+    }
+
+    @Operation(summary = "Create a new student for a course")
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_INSTRUCTOR')")
+    @PostMapping("/post")
+    public Student postStudent(
+            @Parameter(name = "courseId", description = "course ID") @RequestParam Long courseId,
+            @Parameter(name = "email", description = "Email of the student") @RequestParam String email,
+            @Parameter(name = "fname", description = "First name") @RequestParam String fname,
+            @Parameter(name = "githubId", description = "Github ID") @RequestParam Integer githubId,
+            @Parameter(name = "lname", description = "Last name") @RequestParam String lname,
+            @Parameter(name = "studentId", description = "Student ID") @RequestParam String studentId)
+            throws JsonProcessingException {
+
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
+        User u = getCurrentUser().getUser();
+        if (!u.isAdmin()) {
+            courseStaffRepository.findByCourseIdAndGithubId(course.getId(), u.getGithubId())
+                    .orElseThrow(() -> new AccessDeniedException(
+                            "User is not a staff member for this course"));
+        }
+        Student student = Student.builder().courseId(course.getId()).email(email).fname(fname)
+                .githubId(githubId)
+                .lname(lname).studentId(studentId).build();
+        studentRepository.save(student);
+        return student;
+    }
+
+    @Operation(summary = "Upload Students for Course in UCSB Egrades Format")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping(value = "/upload/egrades", consumes = { "multipart/form-data" })
+    public Map<String, String> getStaff(
+            @Parameter(name = "courseId") @RequestParam Long courseId,
+            @Parameter(name = "file") @RequestParam("file") MultipartFile file)
+            throws JsonProcessingException, IOException, CsvException {
+
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
+
+        int counts[] = { 0, 0 };
+
+        try (InputStream inputStream = new BufferedInputStream(file.getInputStream());
+                InputStreamReader reader = new InputStreamReader(inputStream);
+                CSVReader csvReader = new CSVReader(reader);) {
+            csvReader.skip(2);
+            List<String[]> myEntries = csvReader.readAll();
+            for (String[] row : myEntries) {
+                Student student = fromEgradesCSVRow(row);
+                student.setCourseId(course.getId());
+                Status s = upsertStudent(student, course);
+                counts[s.ordinal()]++;
+            }
+        }
+        return Map.of(
+                "filename", file.getOriginalFilename(),
+                "message", String.format("Inserted %d new students, Updated %d students",
+                        counts[Status.INSERTED.ordinal()], counts[Status.UPDATED.ordinal()]));
+
+    }
+
+    public Student fromEgradesCSVRow(String[] row) {
+        return Student.builder()
+                .fname(row[5])
+                .lname(row[4])
+                .studentId(row[1])
+                .email(row[10])
+                .build();
+    }
+
+    public Status upsertStudent(Student student, Course course) {
+        Optional<Student> existingStudent = studentRepository.findByCourseIdAndStudentId(course.getId(),
+                student.getStudentId());
+        if (existingStudent.isPresent()) {
+            Student existingStudentObj = existingStudent.get();
+            existingStudentObj.setFname(student.getFname());
+            existingStudentObj.setLname(student.getLname());
+            existingStudentObj.setEmail(student.getEmail());
+            studentRepository.save(existingStudentObj);
+            return Status.UPDATED;
+        } else {
+            studentRepository.save(student);
+            return Status.INSERTED;
         }
 
-        @Operation(summary = "Upload Students for Course in UCSB Egrades Format")
-        @PreAuthorize("hasRole('ROLE_ADMIN')")
-        @PostMapping(value = "/upload/egrades", consumes = { "multipart/form-data" })
-        public Map<String, String> getStaff(
-                        @Parameter(name = "courseId") @RequestParam Long courseId,
-                        @Parameter(name = "file") @RequestParam("file") MultipartFile file)
-                        throws JsonProcessingException, IOException, CsvException {
-
-                Course course = courseRepository.findById(courseId)
-                                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
-
-                int counts[] = { 0, 0 };
-
-                try (InputStream inputStream = new BufferedInputStream(file.getInputStream());
-                                InputStreamReader reader = new InputStreamReader(inputStream);
-                                CSVReader csvReader = new CSVReader(reader);) {
-                        csvReader.skip(2);
-                        List<String[]> myEntries = csvReader.readAll();
-                        for (String[] row : myEntries) {
-                                Student student = fromEgradesCSVRow(row);
-                                student.setCourseId(course.getId());
-                                Status s = upsertStudent(student, course);
-                                counts[s.ordinal()]++;
-                        }
-                }
-                return Map.of(
-                                "filename", file.getOriginalFilename(),
-                                "message", String.format("Inserted %d new students, Updated %d students",
-                                                counts[Status.INSERTED.ordinal()], counts[Status.UPDATED.ordinal()]));
-
-        }
-
-        public Student fromEgradesCSVRow(String[] row) {
-                return Student.builder()
-                                .fname(row[5])
-                                .lname(row[4])
-                                .studentId(row[1])
-                                .email(row[10])
-                                .build();
-        }
-
-        public Status upsertStudent(Student student, Course course) {
-                Optional<Student> existingStudent = studentRepository.findByCourseIdAndStudentId(course.getId(),
-                                student.getStudentId());
-                if (existingStudent.isPresent()) {
-                        Student existingStudentObj = existingStudent.get();
-                        existingStudentObj.setFname(student.getFname());
-                        existingStudentObj.setLname(student.getLname());
-                        existingStudentObj.setEmail(student.getEmail());
-                        studentRepository.save(existingStudentObj);
-                        return Status.UPDATED;
-                } else {
-                        studentRepository.save(student);
-                        return Status.INSERTED;
-                }
-
-        }
+    }
 
 }

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/StudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/StudentsController.java
@@ -79,7 +79,6 @@ public class StudentsController extends ApiController {
 
     @Operation(summary = "Create a new student for a course")
     @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_INSTRUCTOR', 'ROLE_USER')")
-    // @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public Student postStudent(
             @Parameter(name = "courseId", description = "course ID") @RequestParam Long courseId,

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/StudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/StudentsControllerTests.java
@@ -287,4 +287,26 @@ public class StudentsControllerTests extends ControllerTestCase {
                 verify(studentRepository, atLeastOnce()).save(eq(student3Before));
         }
 
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void user_can_post_student_only_if_they_are_instructor() throws Exception {
+    
+            // arrange
+    
+            ArrayList<Course> expectedCourses = new ArrayList<>();
+            expectedCourses.addAll(Arrays.asList(course1, course2));
+    
+            when(courseRepository.findCoursesStaffedByUser(any())).thenReturn(expectedCourses);
+    
+            // act
+            MvcResult response = mockMvc.perform(get("/api/courses/all"))
+                    .andExpect(status().isOk()).andReturn();
+    
+            // assert
+            verify(courseRepository, atLeastOnce()).findCoursesStaffedByUser(any());
+            String expectedJson = mapper.writeValueAsString(expectedCourses);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+        }
+
 }

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/StudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/StudentsControllerTests.java
@@ -62,6 +62,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 
 import java.util.Map;
+import static org.mockito.ArgumentMatchers.anyLong;
 
 @Slf4j
 @WebMvcTest(controllers = StudentsController.class)
@@ -155,7 +156,7 @@ public class StudentsControllerTests extends ControllerTestCase {
 
                 when(courseRepository.findById(eq(course1.getId()))).thenReturn(Optional.empty());
 
-                // act 
+                // act
                 MvcResult response = mockMvc.perform(get("/api/students/all?courseId=1"))
                                 .andExpect(status().isNotFound()).andReturn();
 
@@ -163,10 +164,9 @@ public class StudentsControllerTests extends ControllerTestCase {
 
                 verify(courseRepository, atLeastOnce()).findById(eq(course1.getId()));
                 String responseString = response.getResponse().getContentAsString();
-                Map<String,String> expectedMap = Map.of(
-                        "type", "EntityNotFoundException",
-                        "message", "Course with id 1 not found"
-                      );
+                Map<String, String> expectedMap = Map.of(
+                                "type", "EntityNotFoundException",
+                                "message", "Course with id 1 not found");
                 String expectedJson = mapper.writeValueAsString(expectedMap);
                 assertEquals(expectedJson, responseString);
         }
@@ -195,10 +195,9 @@ public class StudentsControllerTests extends ControllerTestCase {
 
                 verify(courseRepository, atLeastOnce()).findById(eq(course1.getId()));
                 String responseString = response.getResponse().getContentAsString();
-                Map<String,String> expectedMap = Map.of(
-                        "type", "EntityNotFoundException",
-                        "message", "Course with id 1 not found"
-                      );
+                Map<String, String> expectedMap = Map.of(
+                                "type", "EntityNotFoundException",
+                                "message", "Course with id 1 not found");
                 String expectedJson = mapper.writeValueAsString(expectedMap);
                 assertEquals(expectedJson, responseString);
         }
@@ -217,34 +216,34 @@ public class StudentsControllerTests extends ControllerTestCase {
 
                 // arrange
 
-                 Student student2After = Student.builder()
-                        .id(2L)
-                        .courseId(course1.getId())
-                        .fname("LAUREN")
-                        .lname("DEL PLAYA")
-                        .email("ldelplaya@umail.ucsb.edu")
-                        .studentId("A987654")
-                        .courseId(course1.getId())
-                        .build();
+                Student student2After = Student.builder()
+                                .id(2L)
+                                .courseId(course1.getId())
+                                .fname("LAUREN")
+                                .lname("DEL PLAYA")
+                                .email("ldelplaya@umail.ucsb.edu")
+                                .studentId("A987654")
+                                .courseId(course1.getId())
+                                .build();
 
-                  Student student3Before = Student.builder()
-                        .courseId(course1.getId())
-                        .fname("SABADO")
-                        .lname("TARDE")
-                        .email("sabadotarde@umail.ucsb.edu")
-                        .studentId("1234567")
-                        .courseId(course1.getId())
-                        .build();
+                Student student3Before = Student.builder()
+                                .courseId(course1.getId())
+                                .fname("SABADO")
+                                .lname("TARDE")
+                                .email("sabadotarde@umail.ucsb.edu")
+                                .studentId("1234567")
+                                .courseId(course1.getId())
+                                .build();
 
-                  Student student3After = Student.builder()
-                        .id(2L)
-                        .courseId(course1.getId())
-                        .fname("SABADO")
-                        .lname("TARDE")
-                        .email("sabadotarde@umail.ucsb.edu")
-                        .studentId("1234567")
-                        .courseId(course1.getId())
-                        .build();
+                Student student3After = Student.builder()
+                                .id(2L)
+                                .courseId(course1.getId())
+                                .fname("SABADO")
+                                .lname("TARDE")
+                                .email("sabadotarde@umail.ucsb.edu")
+                                .studentId("1234567")
+                                .courseId(course1.getId())
+                                .build();
 
                 MockMultipartFile file = new MockMultipartFile(
                                 "file",
@@ -273,10 +272,9 @@ public class StudentsControllerTests extends ControllerTestCase {
 
                 verify(courseRepository, atLeastOnce()).findById(eq(course1.getId()));
                 String responseString = response.getResponse().getContentAsString();
-                Map<String,String> expectedMap = Map.of(
-                        "filename", "egrades.csv",
-                        "message", "Inserted 1 new students, Updated 2 students"
-                      );
+                Map<String, String> expectedMap = Map.of(
+                                "filename", "egrades.csv",
+                                "message", "Inserted 1 new students, Updated 2 students");
                 String expectedJson = mapper.writeValueAsString(expectedMap);
                 assertEquals(expectedJson, responseString);
                 verify(studentRepository, atLeastOnce()).findByCourseIdAndStudentId(eq(course1.getId()), eq("A123456"));
@@ -287,26 +285,73 @@ public class StudentsControllerTests extends ControllerTestCase {
                 verify(studentRepository, atLeastOnce()).save(eq(student3Before));
         }
 
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void can_not_post_student_course_dne() throws Exception {
+                when(courseRepository.findById(eq(course1.getId()))).thenReturn(Optional.empty());
+                // act
+                MvcResult response = mockMvc.perform(
+                        post("/api/students/post?courseId=1&email=123@123.123&fname=Chris&lname=Gaucho&studentId=A123456")
+                        .with(csrf()))
+                        .andExpect(status().isNotFound()).andReturn();
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_post_student() throws Exception {
+                Student stu = Student.builder()
+                                .courseId(course1.getId())
+                                .fname("Chris")
+                                .lname("Gaucho")
+                                .email("123@123.123")
+                                .studentId("A123456")
+                                .build();
+                when(courseRepository.findById(anyLong())).thenReturn(Optional.of(course1));
+                when(studentRepository.save(any())).thenReturn(stu);
+                // act
+                MvcResult response = mockMvc.perform(
+                        post("/api/students/post?courseId=1&email=123@123.123&fname=Chris&lname=Gaucho&studentId=A123456").with(csrf()))
+                                .andExpect(status().isOk())
+                                .andReturn();
+                // assert
+                String expectedJson = mapper.writeValueAsString(stu);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
         @WithMockUser(roles = { "USER" })
         @Test
         public void user_can_post_student_only_if_they_are_instructor() throws Exception {
-    
-            // arrange
-    
-            ArrayList<Course> expectedCourses = new ArrayList<>();
-            expectedCourses.addAll(Arrays.asList(course1, course2));
-    
-            when(courseRepository.findCoursesStaffedByUser(any())).thenReturn(expectedCourses);
-    
-            // act
-            MvcResult response = mockMvc.perform(get("/api/courses/all"))
-                    .andExpect(status().isOk()).andReturn();
-    
-            // assert
-            verify(courseRepository, atLeastOnce()).findCoursesStaffedByUser(any());
-            String expectedJson = mapper.writeValueAsString(expectedCourses);
-            String responseString = response.getResponse().getContentAsString();
-            assertEquals(expectedJson, responseString);
+                Student stu = Student.builder()
+                                .courseId(course1.getId())
+                                .fname("Chris")
+                                .lname("Gaucho")
+                                .email("123@123.123")
+                                .studentId("A123456")
+                                .build();
+                when(courseRepository.findById(anyLong())).thenReturn(Optional.of(course1));
+                when(studentRepository.save(any())).thenReturn(stu);
+                when(staffRepository.findByCourseIdAndGithubId(any(),any())).thenReturn(Optional.of(Staff.builder().build()));
+                // act
+                MvcResult response = mockMvc.perform(
+                        post("/api/students/post?courseId=1&email=123@123.123&fname=Chris&lname=Gaucho&studentId=A123456").with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+                // assert
+                verify(staffRepository, atLeastOnce()).findByCourseIdAndGithubId(any(), any());
+                String expectedJson = mapper.writeValueAsString(stu);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void user_can_not_post_student_if_not_instructor() throws Exception {
+                when(courseRepository.findById(anyLong())).thenReturn(Optional.of(course1));
+                when(staffRepository.findByCourseIdAndGithubId(any(),any())).thenReturn(Optional.empty());
+                // act
+                MvcResult response = mockMvc.perform(
+                        post("/api/students/post?courseId=1&email=123@123.123&fname=Chris&lname=Gaucho&studentId=A123456").with(csrf()))
+                                .andExpect(status().isForbidden()).andReturn();
         }
 
 }


### PR DESCRIPTION
In this PR, I created endpoint for creating a single student in the course. 

## Pre-req
Nothing is needed before this branch gets merged. However, this branch can help the test of #46

# Feature
The endpoint is at `/api/students/post`, and shows as follows on swagger:

![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-3/assets/43783877/1a0f22d4-3ec3-4ce0-8c77-b6ccd271be81)


# User story
As an instructor, or teaching team member, I can add students to the repo without batch import. This is useful for students coming from waitlist. 

As a developer, I can test my course controller by adding individual dummy students (when used with the users API).

# Deployment
Our dokku server is running out of memory... Waiting for server

# Limitation
This feature does not have corresponding frontend pages created yet.

This is reqired by https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-3/pull/46

Closes #61